### PR TITLE
Prevent empty lines in yum repo definitions files

### DIFF
--- a/templates/yum.repo.mustache
+++ b/templates/yum.repo.mustache
@@ -1,7 +1,7 @@
-{{#id}}[{{value}}]{{/id}}
-{{#name}}name={{value}}{{/name}}
-{{#baseurl}}baseurl={{value}}{{/baseurl}}
-{{#enabled}}enabled={{value}}{{/enabled}}
-{{#gpgcheck}}gpgcheck={{value}}{{/gpgcheck}}
-{{#gpgkey}}gpgkey={{value}}{{/gpgkey}}
-{{#proxy}}proxy={{value}}{{/proxy}}
+{{#id}}[{{value}}]
+{{/id}}{{#name}}name={{value}}
+{{/name}}{{#baseurl}}baseurl={{value}}
+{{/baseurl}}{{#enabled}}enabled={{value}}
+{{/enabled}}{{#gpgcheck}}gpgcheck={{value}}
+{{/gpgcheck}}{{#gpgkey}}gpgkey={{value}}
+{{/gpgkey}}{{#proxy}}proxy={{value}}{{/proxy}}


### PR DESCRIPTION
By including the newlines within the conditional markers of the mustache
template, we can avoid empty lines in the resulting definition.repo file.

(This gets even more important when you have a lot more optional settings
within the mustache template, but the result is cleaner either way.)
